### PR TITLE
Fix: random segmentation fault during detach using physics mutex

### DIFF
--- a/include/gazebo_ros_link_attacher.h
+++ b/include/gazebo_ros_link_attacher.h
@@ -7,6 +7,8 @@
 #ifndef GAZEBO_ROS_LINK_ATTACHER_HH
 #define GAZEBO_ROS_LINK_ATTACHER_HH
 
+#include <boost/thread/recursive_mutex.hpp>
+
 #include <ros/ros.h>
 
 #include <sdf/sdf.hh>
@@ -72,6 +74,8 @@ namespace gazebo
                              gazebo_ros_link_attacher::Attach::Response &res);
 
         std::vector<fixedJoint> joints;
+
+        boost::recursive_mutex* physics_mutex;
 
         /// \brief The physics engine.
         physics::PhysicsEnginePtr physics;


### PR DESCRIPTION
As already shown [here](https://github.com/pal-robotics/gazebo_ros_link_attacher/pull/11) if a detach is issued during a physics engine update a segmentation fault will be generated, resulting in Gazebo crashing.

I would like to share with you my own solution to the problem which I had the opportunity to extensively test and validate during the development of [this](https://github.com/zabealbe/lego_builder) project. The solution is simple, efficient and reliable and only consists in using the physics mutex accessible through `physics->GetPhysicsUpdateMutex();`